### PR TITLE
Clean up obsolete documentation in daily job

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -3,9 +3,9 @@ name: Cleanup gh-pages
 on:
   # Enable "pull_request" for testing
   # pull_request:
-  # monthly jobs
+  # daily jobs
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 0 * * *'
 
 jobs:
   cleanup:
@@ -26,10 +26,15 @@ jobs:
 
       - name: Cleanup, squash and push
         run: |
-          # Delete branches/directories if no changes in 4 weeks (28 days)
-          for branch in $(find seismo-learn -mindepth 2 -maxdepth 2); do
-            if [ $(find $branch -mtime -28 | wc -l) == 0 ]; then
-              rm -rvf $branch
+          # delete the documentation if the corresponding branch is deleted
+          for dir in $(find seismo-learn -mindepth 2 -maxdepth 2); do
+            # directory is "user/repository/branch"
+            repo=$(dirname $dir)
+            branch=$(basename $dir)
+            # the "git ls-remote" command return nothing if a branch is not found
+            if [[ ! $(git ls-remote --heads https://github.com/${repo} ${branch}) ]]; then
+              echo "Deleting directory $dir..."
+              rm -rvf $dir
             fi
           done
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ push the documentation to the `gh-pages` branch of this repository.
 
 The URL scheme is:
 
-	https://seismo-learn.org/sitepreview/seismo-learn/<repository_name>/<PR_branch_name>
+    https://seismo-learn.org/sitepreview/seismo-learn/<repository_name>/<PR_branch_name>
 
 See https://github.com/seismo-learn/software/pull/29 for the workflow changes.
+
+## Cleanup
+
+The [workflow](.github/workflows/cleanup.yaml) runs daily to:
+
+1. Delete the documentation if the corresponding branch was deleted
+2. Generate a index file, listing all current documentations
+3. Squash all commits into one to avoid increasing repository size


### PR DESCRIPTION
Old behavior: runs a monthly job and check if some documentation are old than 1 month (i.e., the corresponding PR was merged).

New behavior: runs a daily job and check if the corresponding remote branch exists (if a PR was merged, then the branch was deleted, and there is no need to keep the old documentation).

The new workflow runs a daily job to:

1. Delete the documentation if the corresponding branch was deleted
2. Generate an index file, listing all current documentations
3. Squash all commits into one to avoid increasing repository size